### PR TITLE
Create Solutions for TensorFlow Version 1.14 Issue on Elementary OS Loki

### DIFF
--- a/Solutions for TensorFlow Version 1.14 Issue on Elementary OS Loki
+++ b/Solutions for TensorFlow Version 1.14 Issue on Elementary OS Loki
@@ -1,0 +1,3 @@
+Question Summary
+The user is encountering an error when attempting to run a TensorFlow script that utilizes TensorFlow Hub on Elementary OS Loki. The error message indicates that a specific function, PyFunc:0, is not found, which prevents the expected output from being generated.
+


### PR DESCRIPTION
To resolve the issue with TensorFlow 1.14 on Elementary OS Loki, you can try the following solutions:

1.Upgrade TensorFlow: If possible, consider upgrading to a more recent version of TensorFlow, as many bugs and compatibility issues have been addressed in later releases. You can do this using pip:

pip install --upgrade tensorflow

2. Check TensorFlow Hub Compatibility: Ensure that the version of TensorFlow Hub you are using is compatible with TensorFlow 1.14. You can specify a compatible version during installation:

pip install tensorflow-hub==0.6.0

3. Modify the Code: Update your code to ensure that the TensorFlow session is properly initialized. Here’s a revised version of your code:

import tensorflow_hub as hub
import tensorflow as tf

module = hub.Module("onnx/shufflenet/1")
preds = module(tf.random_normal(shape=[1, 3, 224, 224], dtype=tf.float32))

with tf.Session() as sess:
    sess.run(tf.global_variables_initializer())  # Initialize variables
    print(sess.run(preds))
4. import tensorflow_hub as hub
import tensorflow as tf

module = hub.Module("onnx/shufflenet/1")
preds = module(tf.random_normal(shape=[1, 3, 224, 224], dtype=tf.float32))

with tf.Session() as sess:
    sess.run(tf.global_variables_initializer())  # Initialize variables
    print(sess.run(preds))

4. Check Dependencies: Ensure that all dependencies are correctly installed and compatible with your TensorFlow version. You can use:

pip check


